### PR TITLE
(#2) Ensure rolltable output displays correctly

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo --gc --minify"
+command = "hugo --gc"
 
 [context.production.environment]
 HUGO_VERSION = "0.70.0"
@@ -8,20 +8,20 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.split1]
-command = "hugo --gc --minify --enableGitInfo"
+command = "hugo --gc --enableGitInfo"
 
 [context.split1.environment]
 HUGO_VERSION = "0.70.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+command = "hugo --gc --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "0.70.0"
 
 [context.branch-deploy]
-command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+command = "hugo --gc -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
 HUGO_VERSION = "0.70.0"

--- a/static/js/rolltables.js
+++ b/static/js/rolltables.js
@@ -85,7 +85,14 @@ function setResultText(tableName) {
 function toggleTableCollapse(tableName) {
   var collapser = document.getElementById(`rolltable-${tableName}-collapser`)
   var table = getRollTable(tableName);
-  var body = table.lastElementChild
-  body.hidden = !body.hidden
-  
+  var body = table.lastElementChild;
+
+  body.hidden = !body.hidden;
+
+  // Toggle the button view, which is a font-awesome icon declaration
+  if (collapser.firstElementChild.className.match("down")) {
+    collapser.firstElementChild.className = "fas fa-caret-right";
+  } else {
+    collapser.firstElementChild.className = "fas fa-caret-down";
+  }
 }

--- a/static/tables/distinctions.csv
+++ b/static/tables/distinctions.csv
@@ -36,7 +36,7 @@ prefix,"They are"," and",", passionate about"," and afraid of"
 67-68,fatalistic,voluptuous,topiary,washing
 69-70,dedicated,jowly,anatomy,the night
 71-72,courteous,bowlegged,divination,alchemy
-73-74,calm,chibby,candlemaking,canals
+73-74,calm,chubby,candlemaking,canals
 75-76,unreflective,taut,carving,trebuchets
 77-78,outspoken,plush,husbandry,being dirty
 79-80,intolerant,coltish,falconry,corpseants


### PR DESCRIPTION
The minification flag used during production builds (but not local live testing) was stripping semantically important whitespace.

This commit drops the minification, which _may_ lead to a reduced performance but nothing noticeable in local testing.

- Fixes #2 