### PR TITLE
Make rollable table caption more apparent

### DIFF
--- a/layouts/shortcodes/rolltable.html
+++ b/layouts/shortcodes/rolltable.html
@@ -17,7 +17,7 @@
 
 <table class="rolltable" id="rolltable-{{ $name }}">
   <caption>
-    <p>
+    <p class="table-caption">
       <button onclick="toggleTableCollapse({{$name}})" id="rolltable-{{ $name }}-collapser"><i class="fas fa-caret-down"></i></button>
       {{$caption}} Click on the <strong>Result</strong> header to roll automatically. Click on any other header to reroll for that column.
     </p>

--- a/static/css/rolltables.css
+++ b/static/css/rolltables.css
@@ -28,3 +28,10 @@ table.rolltable caption button {
   display: inline-block;
   left: 10px;
 }
+
+table.rolltable caption p.table-caption {
+  background: #EEEEEE;
+  font-style: italic;
+  font-size: 0.75rem;
+  display: flow-root;
+}


### PR DESCRIPTION
I totally missed the fact that there were rollable tables because the caption looks identical to the main text. Hopefully this makes things clearer. 